### PR TITLE
driver: use exact signaling instead of sleep loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,3 +148,7 @@ setup-dev-env:
 	test -d linux || git clone --depth=1 --branch v6.2 https://github.com/torvalds/linux.git
 	cd linux && lima make tinyconfig
 	cd linux && lima make -j
+
+# Usage: make debug LINE=get_command+0x88/0x130
+debug:
+	sudo addr2line -e nasp.ko $(LINE)

--- a/device_driver.c
+++ b/device_driver.c
@@ -9,7 +9,6 @@
  */
 
 #include <linux/uaccess.h>
-#include <linux/delay.h>
 #include <linux/version.h>
 #include <linux/wait.h>
 
@@ -406,14 +405,9 @@ static ssize_t device_read(struct file *file,   /* see include/linux/fs.h   */
     printk("nasp: device_read: length: %lu offset: %llu", length, *offset);
 
     struct command *c = get_command();
-    // wait until command is available
-    while (c == NULL)
+    if (c == NULL)
     {
-        if (msleep_interruptible(25) > 0)
-        {
-            return -EINTR;
-        }
-        c = get_command();
+        return -EFAULT;
     }
 
     int json_length = write_command_to_buffer(device_out_buffer, sizeof device_out_buffer, c);

--- a/device_driver.c
+++ b/device_driver.c
@@ -407,7 +407,7 @@ static ssize_t device_read(struct file *file,   /* see include/linux/fs.h   */
     struct command *c = get_command();
     if (c == NULL)
     {
-        return -EFAULT;
+        return -EINTR;
     }
 
     int json_length = write_command_to_buffer(device_out_buffer, sizeof device_out_buffer, c);


### PR DESCRIPTION
## Description

The sleep loop for waiting for commands to be processed was inefficient since it locks and unlocks the lock in every loop iteration. Besides that the worst case delay could be almost the double of the inner sleep time, which now becomes zero.

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [ ] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
