### PR TITLE
ci: setup go with caching for cli build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
     - name: Setup Golang with cache
       uses: magnetikonline/action-golang-cache@v4
       with:
-        go-version: '1.21'
         go-version-file: nasp/go.mod
 
     - name: Install/setup prerequisites

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,18 @@ jobs:
         submodules: recursive
         path: nasp-kernel-module
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
+    - uses: actions/checkout@v3
+      name: Checkout nasp
+      with:
+        submodules: recursive
+        repository: cisco-open/nasp
+        path: nasp  
+
+    - name: Setup Golang with cache
+      uses: magnetikonline/action-golang-cache@v4
       with:
         go-version: '1.21'
+        go-version-file: nasp/go.mod
 
     - name: Install/setup prerequisites
       working-directory: nasp-kernel-module
@@ -34,13 +42,6 @@ jobs:
       run: |
         make insmod
         sudo dmesg -T
-
-    - uses: actions/checkout@v3
-      name: Checkout nasp
-      with:
-        submodules: recursive
-        repository: cisco-open/nasp
-        path: nasp
 
     - name: Build Nasp CLI
       working-directory: nasp


### PR DESCRIPTION
## Description

This speeds up the build with reducing network traffic by caching go pkgs.

