### PR TITLE
ci: excercise (only) DKMS during the builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,14 +25,25 @@ jobs:
       working-directory: nasp-kernel-module
       run: make setup-vm
 
-    - name: Build the kernel module
+    - name: Test build with DKMS
       working-directory: nasp-kernel-module
-      run: make -j$(nproc)
+      run: |
+        sudo cp -r . /usr/src/nasp-0.1.0/
+        sudo dkms add -m nasp -v 0.1.0
+        if sudo dkms build -m nasp -v 0.1.0; then
+          echo "DKMS build succeeded"
+        else
+          echo "DKMS build failed"
+          cat /var/lib/dkms/nasp/0.1.0/build/make.log
+          exit 1
+        fi
+        sudo dkms install -m nasp -v 0.1.0
 
     - name: Run the kernel module
       working-directory: nasp-kernel-module 
       run: |
-        make insmod
+        sudo modprobe tls
+        sudo modprobe nasp
         sudo dmesg -T
 
     - uses: actions/checkout@v3
@@ -62,16 +73,17 @@ jobs:
         sleep 2
 
         # Test downloading a bigger file
-        curl -v -o /tmp/opa_downloaded.o http://localhost:8000/opa.o
+        truncate -s 2M bigfile.o
+        curl -v -o /tmp/bigfile_downloaded.o http://localhost:8000/bigfile.o
 
         # Test uploading this file
-        curl -v -F "opa_downloaded.o.o=@/tmp/opa_downloaded.o" http://localhost:8000/upload
-        diff opa.o opa_downloaded.o
+        curl -v -F "bigfile_downloaded.o=@/tmp/bigfile_downloaded.o" http://localhost:8000/upload
+        diff bigfile.o bigfile_downloaded.o
 
         # Test bearssl with non-bearssl compatibility
         python3 -m http.server 7000 &
         sleep 1
-        curl -k -v -o /dev/null https://localhost:7000/opa.o
+        curl -k -v https://localhost:7000/
 
         # Test sendfile with NGiNX
         curl -v http://localhost:8080
@@ -82,20 +94,4 @@ jobs:
         sudo pkill -9 nasp
 
     - name: Cleanup module
-      working-directory: nasp-kernel-module
-      run: make rmmod
-
-    - name: Test DKMS
-      working-directory: nasp-kernel-module
-      run: |
-        sudo cp -r . /usr/src/nasp-0.1.0/
-        sudo dkms add -m nasp -v 0.1.0
-        if sudo dkms build -m nasp -v 0.1.0; then
-          echo "DKMS build succeeded"
-        else
-          echo "DKMS build failed"
-          cat /var/lib/dkms/nasp/0.1.0/build/make.log
-          exit 1
-        fi
-        sudo dkms install -m nasp -v 0.1.0
-        sudo dmesg -T
+      run: sudo modprobe -r nasp

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       working-directory: nasp-kernel-module
       run: make setup-vm
 
-    - name: Test build with DKMS
+    - name: Build with DKMS
       working-directory: nasp-kernel-module
       run: |
         sudo cp -r . /usr/src/nasp-0.1.0/

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,6 @@ _install_wasm_target:
 	sudo rustup target add wasm32-unknown-unknown
 
 setup-vm: _debian_deps _install_opa _install_wasm_target
-	sudo cp /sys/kernel/btf/vmlinux /usr/lib/modules/`uname -r`/build/
 
 setup-archlinux-vm: _archlinux_deps _install_opa _install_wasm_target
 

--- a/Makefile
+++ b/Makefile
@@ -131,13 +131,11 @@ _install_opa:
 	sudo chmod +x /usr/bin/opa
 
 _install_wasm_target:
-ifndef GITHUB_ACTION
 	sudo curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 	sudo ln -s $$HOME/.cargo/bin/* /usr/bin/
 	rustup default stable
 	rustup target add wasm32-unknown-unknown
 	sudo rustup default stable
-endif
 	sudo rustup target add wasm32-unknown-unknown
 
 setup-vm: _debian_deps _install_opa _install_wasm_target

--- a/Makefile
+++ b/Makefile
@@ -131,11 +131,13 @@ _install_opa:
 	sudo chmod +x /usr/bin/opa
 
 _install_wasm_target:
+ifndef GITHUB_ACTION
 	sudo curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 	sudo ln -s $$HOME/.cargo/bin/* /usr/bin/
 	rustup default stable
 	rustup target add wasm32-unknown-unknown
 	sudo rustup default stable
+endif
 	sudo rustup target add wasm32-unknown-unknown
 
 setup-vm: _debian_deps _install_opa _install_wasm_target

--- a/Makefile
+++ b/Makefile
@@ -114,15 +114,17 @@ insmod-with-proxywasm: insmod-bearssl
 
 rmmod:
 	sudo rmmod nasp
-	sudo rm -f /run/nasp.socket
 	sudo rmmod bearssl
 
 _debian_deps:
 	sudo apt update
-	sudo apt install -y clang libbpf-dev dwarves build-essential linux-tools-generic golang dkms flex bison iperf socat
+	sudo apt install -y build-essential dkms dwarves
+ifndef GITHUB_ACTION
+	sudo apt install -y golang flex bison iperf socat
+endif
 
 _archlinux_deps:
-	sudo pacman -Syu linux-headers base-devel clang go dkms git strace bc iperf socat
+	sudo pacman -Syu linux-headers base-devel go dkms git strace bc iperf socat
 
 _install_opa:
 	sudo curl -L -o /usr/bin/opa https://openpolicyagent.org/downloads/v0.56.0/opa_linux_$(shell go version | cut -f2 -d'/')_static
@@ -139,7 +141,7 @@ _install_wasm_target:
 setup-vm: _debian_deps _install_opa _install_wasm_target
 	sudo cp /sys/kernel/btf/vmlinux /usr/lib/modules/`uname -r`/build/
 
-setup-archlinux-vm: _archlinux_deps _install_opa
+setup-archlinux-vm: _archlinux_deps _install_opa _install_wasm_target
 
 setup-dev-env:
 	test -f .vscode/c_cpp_properties.json || cp .vscode/c_cpp_properties.json.orig .vscode/c_cpp_properties.json


### PR DESCRIPTION
## Description

This reduces build time also, but the main point of this is to test our official installation method (and only that) during the builds, which is DKMS. Install less garbage during GitHub Actions runs.

