### PR TITLE
Initial impl of cert bundle caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ nasp-objs :=  third-party/wasm3/source/m3_api_libc.o \
 			  main.o \
 			  csr.o \
 			  rsa_tools.o \
+			  cert_tools.o \
 			  wasm.o \
 			  opa.o \
 			  proxywasm.o \

--- a/cert_tools.c
+++ b/cert_tools.c
@@ -20,6 +20,8 @@ static LIST_HEAD(cert_list);
 static DEFINE_SPINLOCK(cert_list_lock);
 static unsigned long cert_list_lock_flags;
 
+//add_cert_to_cache adds a certificate chain with a given trust anchor to a linked list. The key will identify this entry.
+//the function is thread safe. 
 void add_cert_to_cache(u16 key, br_x509_certificate *chain, size_t chain_len, 
     br_x509_trust_anchor *trust_anchors, size_t trust_anchors_len)
 {
@@ -42,6 +44,8 @@ void add_cert_to_cache(u16 key, br_x509_certificate *chain, size_t chain_len,
     spin_unlock_irqrestore(&cert_list_lock, cert_list_lock_flags);
 }
 
+//find_cert_from_cache tries to find a certificate bundle for the given key. In case of failure it returns a NULL.
+//the function is thread safe
 cert_with_key *find_cert_from_cache(u32 key) 
 {
     cert_with_key *cert_bundle;
@@ -58,6 +62,8 @@ cert_with_key *find_cert_from_cache(u32 key)
     return 0;
 }
 
+//remove_cert_from_cache removes a given certificate bundle from the cache
+//the function is thread safe
 void remove_cert_from_cache(cert_with_key *cert_bundle)
 {
     if (cert_bundle)
@@ -69,4 +75,46 @@ void remove_cert_from_cache(cert_with_key *cert_bundle)
         kfree(cert_bundle);
         spin_unlock_irqrestore(&cert_list_lock, cert_list_lock_flags);
     }
+}
+
+//validate_cert validates the given certificate if it has expired or not.
+bool validate_cert(br_x509_certificate *cert)
+{
+    bool result = false;
+
+    br_x509_decoder_context dc;
+
+    br_x509_decoder_init(&dc, 0, 0);
+    br_x509_decoder_push(&dc, cert->data, cert->data_len);
+    int err = br_x509_decoder_last_error(&dc);
+    if (err != 0)
+    {
+        pr_err("cert_tools: cert decode faild during cert validation %d", err);
+        return result;
+    }
+
+    // Check if the cert is valid
+    uint32_t nbs = dc.notbefore_seconds;
+    uint32_t nbd = dc.notbefore_days;
+    uint32_t nas = dc.notafter_seconds;
+    uint32_t nad = dc.notafter_days;
+
+    time64_t x = ktime_get_real_seconds();
+    uint32_t vd = (uint32_t)(x / 86400) + 719528;
+    uint32_t vs = (uint32_t)(x % 86400);
+
+    if (vd < nbd || (vd == nbd && vs < nbs))
+    {
+        pr_warn("cert_tools: cert expired");
+    }
+    else if (vd > nad || (vd == nad && vs > nas))
+    {
+        pr_warn("cert_tools: cert not valid yet");
+    }
+    else
+    {
+       result = true;
+    }
+
+    return result;
 }

--- a/cert_tools.c
+++ b/cert_tools.c
@@ -108,18 +108,18 @@ cert_with_key *find_cert_from_cache(char *key)
 
 // remove_cert_from_cache_locked removes a given certificate bundle from the cache
 // the function is thread safe
-void remove_cert_from_cache_locked(cert_with_key *cert_bundle)
+void remove_cert_from_cache(cert_with_key *cert_bundle)
 {
     if (cert_bundle)
     {
         spin_lock_irqsave(&cert_cache_lock, cert_cache_lock_flags);
-        remove_cert_from_cache(cert_bundle);
+        remove_cert_from_cache_locked(cert_bundle);
         spin_unlock_irqrestore(&cert_cache_lock, cert_cache_lock_flags);
     }
 }
 
 // remove_cert_from_cache removes a given certificate bundle from the cache
-void remove_cert_from_cache(cert_with_key *cert_bundle)
+void remove_cert_from_cache_locked(cert_with_key *cert_bundle)
 {
     if (cert_bundle)
     {

--- a/cert_tools.c
+++ b/cert_tools.c
@@ -8,11 +8,10 @@
  * modified, or distributed except according to those terms.
  */
 
-#include "cert_tools.h"
+#include <linux/list.h>
+#include <linux/slab.h>
 
-#include "linux/list.h"
-#include "linux/slab.h"
-#include "rsa_tools.h"
+#include "cert_tools.h"
 #include "string.h"
 
 // Define the maximum number of elements inside the cache
@@ -22,8 +21,17 @@
 static LIST_HEAD(cert_cache);
 
 // lock for the above list to make it thread safe
-static DEFINE_SPINLOCK(cert_cache_lock);
-static unsigned long cert_cache_lock_flags;
+static DEFINE_MUTEX(certificate_cache_lock);
+
+void cert_cache_lock(void)
+{
+    mutex_lock(&certificate_cache_lock);
+}
+
+void cert_cache_unlock(void)
+{
+    mutex_unlock(&certificate_cache_lock);
+}
 
 static size_t linkedlist_length(struct list_head *head)
 {
@@ -40,8 +48,7 @@ static size_t linkedlist_length(struct list_head *head)
 
 // add_cert_to_cache adds a certificate chain with a given trust anchor to a linked list. The key will identify this entry.
 // the function is thread safe.
-void add_cert_to_cache(char *key, br_x509_certificate *chain, size_t chain_len,
-                       br_x509_trust_anchor *trust_anchors, size_t trust_anchors_len)
+void add_cert_to_cache(char *key, x509_certificate *cert)
 {
     pr_err("adding certificate to cache");
     if (!key)
@@ -49,42 +56,52 @@ void add_cert_to_cache(char *key, br_x509_certificate *chain, size_t chain_len,
         pr_err("cert_tools: provided key is null");
         return;
     }
-    if (linkedlist_length(&cert_cache) >= MAX_CACHE_LENGTH)
-    {
-        // TODO handle cases when cache length is maxed out but no expired certificate
-        remove_unused_expired_certs_from_cache();
-    }
+
+    remove_unused_expired_certs_from_cache();
+
     cert_with_key *new_entry = kzalloc(sizeof(cert_with_key), GFP_KERNEL);
     if (!new_entry)
     {
         pr_err("cert_tools: memory allocation error");
         return;
     }
+    if (!key)
+    {
+        pr_err("cert_tools: provided key is null");
+        return;
+    }
     new_entry->key = strdup(key);
-    new_entry->chain = chain;
-    new_entry->chain_len = chain_len;
-    new_entry->trust_anchors = trust_anchors;
-    new_entry->trust_anchors_len = trust_anchors_len;
+    new_entry->cert = cert;
 
-    spin_lock_irqsave(&cert_cache_lock, cert_cache_lock_flags);
+    cert_cache_lock();
     INIT_LIST_HEAD(&new_entry->list);
     list_add(&new_entry->list, &cert_cache);
-    spin_unlock_irqrestore(&cert_cache_lock, cert_cache_lock_flags);
+    cert_cache_unlock();
 }
+
 // remove_unused_expired_certs_from_cache iterates over the whole cache and tries to clean up the unused/expired certificates.
 // it works like a garbage collection which now runs before every add.
+// TODO handle cases when cache length is maxed out but no expired certificate
 void remove_unused_expired_certs_from_cache()
 {
     cert_with_key *cert_bundle, *cert_bundle_tmp;
-    spin_lock_irqsave(&cert_cache_lock, cert_cache_lock_flags);
+
+    if (linkedlist_length(&cert_cache) < MAX_CACHE_LENGTH)
+    {
+        return;
+    }
+
+    cert_cache_lock();
     list_for_each_entry_safe_reverse(cert_bundle, cert_bundle_tmp, &cert_cache, list)
     {
-        if (!validate_cert(cert_bundle->chain))
+        if (!validate_cert(cert_bundle->cert->chain))
         {
+            cert_cache_unlock();
             remove_cert_from_cache(cert_bundle);
+            cert_cache_lock();
         }
     }
-    spin_unlock_irqrestore(&cert_cache_lock, cert_cache_lock_flags);
+    cert_cache_unlock();
 }
 
 // find_cert_from_cache tries to find a certificate bundle for the given key. In case of failure it returns a NULL.
@@ -92,17 +109,16 @@ void remove_unused_expired_certs_from_cache()
 cert_with_key *find_cert_from_cache(char *key)
 {
     cert_with_key *cert_bundle;
-    spin_lock_irqsave(&cert_cache_lock, cert_cache_lock_flags);
+    cert_cache_lock();
     list_for_each_entry(cert_bundle, &cert_cache, list)
     {
         if (strncmp(cert_bundle->key, key, strlen(key)) == 0)
         {
-            pr_err("found cert in the cache using it");
-            spin_unlock_irqrestore(&cert_cache_lock, cert_cache_lock_flags);
+            cert_cache_unlock();
             return cert_bundle;
         }
     }
-    spin_unlock_irqrestore(&cert_cache_lock, cert_cache_lock_flags);
+    cert_cache_unlock();
     return 0;
 }
 
@@ -112,9 +128,9 @@ void remove_cert_from_cache(cert_with_key *cert_bundle)
 {
     if (cert_bundle)
     {
-        spin_lock_irqsave(&cert_cache_lock, cert_cache_lock_flags);
+        cert_cache_lock();
         remove_cert_from_cache_locked(cert_bundle);
-        spin_unlock_irqrestore(&cert_cache_lock, cert_cache_lock_flags);
+        cert_cache_unlock();
     }
 }
 
@@ -124,9 +140,7 @@ void remove_cert_from_cache_locked(cert_with_key *cert_bundle)
     if (cert_bundle)
     {
         list_del(&cert_bundle->list);
-        kfree(cert_bundle->key);
-        free_br_x509_certificate(cert_bundle->chain, cert_bundle->chain_len);
-        free_br_x509_trust_anchors(cert_bundle->trust_anchors, cert_bundle->trust_anchors_len);
+        x509_certificate_put(cert_bundle->cert);
         kfree(cert_bundle);
     }
 }
@@ -171,4 +185,64 @@ bool validate_cert(br_x509_certificate *cert)
     }
 
     return result;
+}
+
+x509_certificate *x509_certificate_init(void)
+{
+    x509_certificate *cert = kzalloc(sizeof(x509_certificate), GFP_KERNEL);
+
+    kref_init(&cert->kref);
+
+    return cert;
+}
+
+void x509_certificate_get(x509_certificate *cert)
+{
+    kref_get(&cert->kref);
+}
+
+void x509_certificate_put(x509_certificate *cert)
+{
+    kref_put(&cert->kref, x509_certificate_release);
+}
+
+void x509_certificate_release(struct kref *kref)
+{
+    x509_certificate *cert = container_of(kref, x509_certificate, kref);
+
+    x509_certificate_free(cert);
+}
+
+void x509_certificate_free(x509_certificate *cert)
+{
+    pr_info("nasp: x509_certificate_free");
+
+    if (cert == NULL)
+    {
+        return;
+    }
+
+    if (cert->chain_len > 0)
+    {
+        size_t i;
+        for (i = 0; i < cert->chain_len; i++)
+        {
+            kfree(cert->chain[i].data);
+        }
+    }
+    kfree(cert->chain);
+
+    if (cert->trust_anchors_len > 0)
+    {
+        size_t i;
+        for (i = 0; i < cert->trust_anchors_len; i++)
+        {
+            kfree(cert->trust_anchors[i].dn.data);
+            kfree(cert->trust_anchors[i].pkey.key.rsa.n);
+            kfree(cert->trust_anchors[i].pkey.key.rsa.e);
+        }
+    }
+    kfree(cert->trust_anchors);
+
+    kfree(cert);
 }

--- a/cert_tools.c
+++ b/cert_tools.c
@@ -25,15 +25,15 @@ static unsigned long cert_cache_lock_flags;
 void add_cert_to_cache(char* key, br_x509_certificate *chain, size_t chain_len,
                        br_x509_trust_anchor *trust_anchors, size_t trust_anchors_len)
 {
+    if (!key)
+    {
+        pr_err("cert_tools: provided key is null");
+        return;
+    }
     cert_with_key *new_entry = kzalloc(sizeof(cert_with_key), GFP_KERNEL);
     if (!new_entry)
     {
         pr_err("cert_tools: memory allocation error");
-        return;
-    }
-    if (!key)
-    {
-        pr_err("cert_tools: provided key is null");
         return;
     }
     new_entry->key = key;
@@ -74,6 +74,7 @@ void remove_cert_from_cache(cert_with_key *cert_bundle)
     {
         spin_lock_irqsave(&cert_cache_lock, cert_cache_lock_flags);
         list_del(&cert_bundle->list);
+        kfree(cert_bundle->chain->data);
         kfree(cert_bundle->chain);
         kfree(cert_bundle->trust_anchors);
         kfree(cert_bundle);

--- a/cert_tools.c
+++ b/cert_tools.c
@@ -51,7 +51,7 @@ void add_cert_to_cache(char *key, br_x509_certificate *chain, size_t chain_len,
     }
     if (linkedlist_length(&cert_cache) >= MAX_CACHE_LENGTH)
     {
-        // TODO handle cases when cache lenght is maxed out but no expired certificate
+        // TODO handle cases when cache length is maxed out but no expired certificate
         remove_unused_expired_certs_from_cache();
     }
     cert_with_key *new_entry = kzalloc(sizeof(cert_with_key), GFP_KERNEL);

--- a/cert_tools.c
+++ b/cert_tools.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023 Cisco and/or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT OR GPL-2.0-only
+ *
+ * Licensed under the MIT license <LICENSE.MIT or https://opensource.org/licenses/MIT> or the GPLv2 license
+ * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied,
+ * modified, or distributed except according to those terms.
+ */
+
+#include "cert_tools.h"
+
+#include "linux/list.h"
+
+
+// certs that are in use or used once by a workload
+static LIST_HEAD(cert_list);
+
+//lock for the above list to make it thread safe
+static DEFINE_SPINLOCK(cert_list_lock);
+static unsigned long cert_list_lock_flags;
+
+void add_cert_to_cache(u16 key, br_x509_certificate *chain, size_t chain_len, 
+    br_x509_trust_anchor *trust_anchors, size_t trust_anchors_len)
+{
+    cert_with_key *new_entry = kzalloc(sizeof(cert_with_key), GFP_KERNEL);
+    if (!new_entry)
+    {
+        pr_err("cert_tools: memory allocation error");
+        return;
+    }
+    new_entry->key = key;
+    new_entry->chain = chain;
+    new_entry->chain_len = chain_len;
+    new_entry->trust_anchors = trust_anchors;
+    new_entry->trust_anchors_len  = trust_anchors_len;
+
+
+    spin_lock_irqsave(&cert_list_lock, cert_list_lock_flags);
+    INIT_LIST_HEAD(&new_entry->list);
+    list_add(&new_entry->list, &cert_list);
+    spin_unlock_irqrestore(&cert_list_lock, cert_list_lock_flags);
+}
+
+cert_with_key *find_cert_from_cache(u32 key) 
+{
+    cert_with_key *cert_bundle;
+    spin_lock_irqsave(&cert_list_lock, cert_list_lock_flags);
+    list_for_each_entry(cert_bundle, &cert_list, list)
+    {
+        if (cert_bundle->key == key)
+        {   
+            spin_unlock_irqrestore(&cert_list_lock, cert_list_lock_flags);
+            return cert_bundle;
+        }
+    }
+    spin_unlock_irqrestore(&cert_list_lock, cert_list_lock_flags);
+    return 0;
+}
+
+void remove_cert_from_cache(cert_with_key *cert_bundle)
+{
+    if (cert_bundle)
+    {
+        spin_lock_irqsave(&cert_list_lock, cert_list_lock_flags);
+        list_del(&cert_bundle->list);
+        kfree(cert_bundle->chain);
+        kfree(cert_bundle->trust_anchors);
+        kfree(cert_bundle);
+        spin_unlock_irqrestore(&cert_list_lock, cert_list_lock_flags);
+    }
+}

--- a/cert_tools.h
+++ b/cert_tools.h
@@ -17,10 +17,10 @@
 
 typedef struct
 {
-    uint32_t nbs;
-    uint32_t nbd;
-    uint32_t nas;
-    uint32_t nad;
+    uint32_t notbefore_seconds;
+    uint32_t notbefore_days;
+    uint32_t notafter_seconds;
+    uint32_t notafter_days;
 } x509_certificate_validity;
 
 typedef struct
@@ -52,6 +52,6 @@ void remove_cert_from_cache_locked(cert_with_key *cert);
 void remove_unused_expired_certs_from_cache(void);
 
 bool validate_cert(x509_certificate_validity cert_validity);
-int decode_cert(x509_certificate *x509_cert);
+int set_cert_validity(x509_certificate *x509_cert);
 
 #endif

--- a/cert_tools.h
+++ b/cert_tools.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2023 Cisco and/or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT OR GPL-2.0-only
+ *
+ * Licensed under the MIT license <LICENSE.MIT or https://opensource.org/licenses/MIT> or the GPLv2 license
+ * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied,
+ * modified, or distributed except according to those terms.
+ */
+
+#ifndef cert_tools_h
+#define cert_tools_h
+
+#include "bearssl.h"
+#include "linux/slab.h"
+
+typedef struct
+{
+	u32 key;
+	br_x509_certificate *chain;
+    size_t chain_len;
+    br_x509_trust_anchor *trust_anchors;
+    size_t trust_anchors_len;
+    struct list_head list;
+} cert_with_key;
+
+void add_cert_to_cache(u16 key, br_x509_certificate *chain, size_t chain_len, 
+    br_x509_trust_anchor *trust_anchors, size_t trust_anchors_len);
+cert_with_key *find_cert_from_cache(u32 key);
+void remove_cert_from_cache(cert_with_key *cert);
+
+#endif

--- a/cert_tools.h
+++ b/cert_tools.h
@@ -28,5 +28,6 @@ void add_cert_to_cache(u16 key, br_x509_certificate *chain, size_t chain_len,
     br_x509_trust_anchor *trust_anchors, size_t trust_anchors_len);
 cert_with_key *find_cert_from_cache(u32 key);
 void remove_cert_from_cache(cert_with_key *cert);
+bool validate_cert(br_x509_certificate *cert);
 
 #endif

--- a/cert_tools.h
+++ b/cert_tools.h
@@ -15,7 +15,7 @@
 
 typedef struct
 {
-    char* key;
+    char *key;
     br_x509_certificate *chain;
     size_t chain_len;
     br_x509_trust_anchor *trust_anchors;
@@ -23,10 +23,11 @@ typedef struct
     struct list_head list;
 } cert_with_key;
 
-void add_cert_to_cache(char* key, br_x509_certificate *chain, size_t chain_len,
+void add_cert_to_cache(char *key, br_x509_certificate *chain, size_t chain_len,
                        br_x509_trust_anchor *trust_anchors, size_t trust_anchors_len);
-cert_with_key *find_cert_from_cache(char* key);
+cert_with_key *find_cert_from_cache(char *key);
 void remove_cert_from_cache(cert_with_key *cert);
+void remove_cert_from_cache_locked(cert_with_key *cert);
 bool validate_cert(br_x509_certificate *cert);
 void remove_unused_expired_certs_from_cache(void);
 

--- a/cert_tools.h
+++ b/cert_tools.h
@@ -28,5 +28,6 @@ void add_cert_to_cache(char* key, br_x509_certificate *chain, size_t chain_len,
 cert_with_key *find_cert_from_cache(char* key);
 void remove_cert_from_cache(cert_with_key *cert);
 bool validate_cert(br_x509_certificate *cert);
+void remove_unused_expired_certs_from_cache(void);
 
 #endif

--- a/cert_tools.h
+++ b/cert_tools.h
@@ -17,11 +17,21 @@
 
 typedef struct
 {
+    uint32_t nbs;
+    uint32_t nbd;
+    uint32_t nas;
+    uint32_t nad;
+} x509_certificate_validity;
+
+typedef struct
+{
     struct kref kref;
     br_x509_certificate *chain;
     size_t chain_len;
     br_x509_trust_anchor *trust_anchors;
     size_t trust_anchors_len;
+
+    x509_certificate_validity validity;
 } x509_certificate;
 
 typedef struct
@@ -32,8 +42,6 @@ typedef struct
 } cert_with_key;
 
 x509_certificate *x509_certificate_init(void);
-void x509_certificate_release(struct kref *kref);
-void x509_certificate_free(x509_certificate *cert);
 void x509_certificate_get(x509_certificate *cert);
 void x509_certificate_put(x509_certificate *cert);
 
@@ -41,10 +49,9 @@ void add_cert_to_cache(char *key, x509_certificate *cert);
 cert_with_key *find_cert_from_cache(char *key);
 void remove_cert_from_cache(cert_with_key *cert);
 void remove_cert_from_cache_locked(cert_with_key *cert);
-bool validate_cert(br_x509_certificate *cert);
 void remove_unused_expired_certs_from_cache(void);
 
-void cert_cache_lock(void);
-void cert_cache_unlock(void);
+bool validate_cert(x509_certificate_validity cert_validity);
+int decode_cert(x509_certificate *x509_cert);
 
 #endif

--- a/cert_tools.h
+++ b/cert_tools.h
@@ -12,20 +12,19 @@
 #define cert_tools_h
 
 #include "bearssl.h"
-#include "linux/slab.h"
 
 typedef struct
 {
-	u32 key;
-	br_x509_certificate *chain;
+    u32 key;
+    br_x509_certificate *chain;
     size_t chain_len;
     br_x509_trust_anchor *trust_anchors;
     size_t trust_anchors_len;
     struct list_head list;
 } cert_with_key;
 
-void add_cert_to_cache(u16 key, br_x509_certificate *chain, size_t chain_len, 
-    br_x509_trust_anchor *trust_anchors, size_t trust_anchors_len);
+void add_cert_to_cache(u16 key, br_x509_certificate *chain, size_t chain_len,
+                       br_x509_trust_anchor *trust_anchors, size_t trust_anchors_len);
 cert_with_key *find_cert_from_cache(u32 key);
 void remove_cert_from_cache(cert_with_key *cert);
 bool validate_cert(br_x509_certificate *cert);

--- a/cert_tools.h
+++ b/cert_tools.h
@@ -15,7 +15,7 @@
 
 typedef struct
 {
-    u32 key;
+    char* key;
     br_x509_certificate *chain;
     size_t chain_len;
     br_x509_trust_anchor *trust_anchors;
@@ -23,9 +23,9 @@ typedef struct
     struct list_head list;
 } cert_with_key;
 
-void add_cert_to_cache(u16 key, br_x509_certificate *chain, size_t chain_len,
+void add_cert_to_cache(char* key, br_x509_certificate *chain, size_t chain_len,
                        br_x509_trust_anchor *trust_anchors, size_t trust_anchors_len);
-cert_with_key *find_cert_from_cache(u32 key);
+cert_with_key *find_cert_from_cache(char* key);
 void remove_cert_from_cache(cert_with_key *cert);
 bool validate_cert(br_x509_certificate *cert);
 

--- a/commands.c
+++ b/commands.c
@@ -292,8 +292,8 @@ csr_sign_answer *send_csrsign_command(unsigned char *csr)
         csr_sign_answer->chain_len = 1;
 
         srclen = strlen(raw);
-        csr_sign_answer->chain[0].data = kmalloc(srclen, GFP_KERNEL);
-        csr_sign_answer->chain[0].data_len = base64_decode(csr_sign_answer->chain[0].data, srclen, raw, srclen);
+        csr_sign_answer->chain->data = kmalloc(srclen, GFP_KERNEL);
+        csr_sign_answer->chain->data_len = base64_decode(csr_sign_answer->chain->data, srclen, raw, srclen);
     }
 
     return csr_sign_answer;

--- a/commands.c
+++ b/commands.c
@@ -237,28 +237,30 @@ csr_sign_answer *send_csrsign_command(unsigned char *csr)
             goto error;
         }
 
-        csr_sign_answer->trust_anchors_len = json_array_get_count(trust_anchors);
+        csr_sign_answer->cert = x509_certificate_init();
+
+        csr_sign_answer->cert->trust_anchors_len = json_array_get_count(trust_anchors);
         size_t srclen;
 
-        if (csr_sign_answer->trust_anchors_len > 0)
+        if (csr_sign_answer->cert->trust_anchors_len > 0)
         {
-            csr_sign_answer->trust_anchors = kmalloc(csr_sign_answer->trust_anchors_len * sizeof *csr_sign_answer->trust_anchors, GFP_KERNEL);
+            csr_sign_answer->cert->trust_anchors = kmalloc(csr_sign_answer->cert->trust_anchors_len * sizeof *csr_sign_answer->cert->trust_anchors, GFP_KERNEL);
 
             size_t u;
-            for (u = 0; u < csr_sign_answer->trust_anchors_len; u++)
+            for (u = 0; u < csr_sign_answer->cert->trust_anchors_len; u++)
             {
                 JSON_Object *ta = json_array_get_object(trust_anchors, u);
 
-                csr_sign_answer->trust_anchors[u].flags = BR_X509_TA_CA;
-                csr_sign_answer->trust_anchors[u].pkey.key_type = BR_KEYTYPE_RSA;
+                csr_sign_answer->cert->trust_anchors[u].flags = BR_X509_TA_CA;
+                csr_sign_answer->cert->trust_anchors[u].pkey.key_type = BR_KEYTYPE_RSA;
 
                 // RAW (DN)
                 const char *raw_subject = json_object_get_string(ta, "rawSubject");
                 if (raw_subject != NULL)
                 {
                     srclen = strlen(raw_subject);
-                    csr_sign_answer->trust_anchors[u].dn.data = kmalloc(srclen, GFP_KERNEL);
-                    csr_sign_answer->trust_anchors[u].dn.len = base64_decode(csr_sign_answer->trust_anchors[u].dn.data, srclen, raw_subject, srclen);
+                    csr_sign_answer->cert->trust_anchors[u].dn.data = kmalloc(srclen, GFP_KERNEL);
+                    csr_sign_answer->cert->trust_anchors[u].dn.len = base64_decode(csr_sign_answer->cert->trust_anchors[u].dn.data, srclen, raw_subject, srclen);
                 }
 
                 // RSA_N
@@ -266,8 +268,8 @@ csr_sign_answer *send_csrsign_command(unsigned char *csr)
                 if (rsa_n != NULL)
                 {
                     srclen = strlen(rsa_n);
-                    csr_sign_answer->trust_anchors[u].pkey.key.rsa.n = kmalloc(srclen, GFP_KERNEL);
-                    csr_sign_answer->trust_anchors[u].pkey.key.rsa.nlen = base64_decode(csr_sign_answer->trust_anchors[u].pkey.key.rsa.n, srclen, rsa_n, srclen);
+                    csr_sign_answer->cert->trust_anchors[u].pkey.key.rsa.n = kmalloc(srclen, GFP_KERNEL);
+                    csr_sign_answer->cert->trust_anchors[u].pkey.key.rsa.nlen = base64_decode(csr_sign_answer->cert->trust_anchors[u].pkey.key.rsa.n, srclen, rsa_n, srclen);
                 }
 
                 // RSA_E
@@ -275,8 +277,8 @@ csr_sign_answer *send_csrsign_command(unsigned char *csr)
                 if (rsa_e != NULL)
                 {
                     srclen = strlen(rsa_e);
-                    csr_sign_answer->trust_anchors[u].pkey.key.rsa.e = kmalloc(srclen, GFP_KERNEL);
-                    csr_sign_answer->trust_anchors[u].pkey.key.rsa.elen = base64_decode(csr_sign_answer->trust_anchors[u].pkey.key.rsa.e, srclen, rsa_e, srclen);
+                    csr_sign_answer->cert->trust_anchors[u].pkey.key.rsa.e = kmalloc(srclen, GFP_KERNEL);
+                    csr_sign_answer->cert->trust_anchors[u].pkey.key.rsa.elen = base64_decode(csr_sign_answer->cert->trust_anchors[u].pkey.key.rsa.e, srclen, rsa_e, srclen);
                 }
             }
         }
@@ -288,12 +290,12 @@ csr_sign_answer *send_csrsign_command(unsigned char *csr)
             goto error;
         }
 
-        csr_sign_answer->chain = kzalloc(1 * sizeof *csr_sign_answer->chain, GFP_KERNEL);
-        csr_sign_answer->chain_len = 1;
+        csr_sign_answer->cert->chain = kzalloc(1 * sizeof *csr_sign_answer->cert->chain, GFP_KERNEL);
+        csr_sign_answer->cert->chain_len = 1;
 
         srclen = strlen(raw);
-        csr_sign_answer->chain->data = kmalloc(srclen, GFP_KERNEL);
-        csr_sign_answer->chain->data_len = base64_decode(csr_sign_answer->chain->data, srclen, raw, srclen);
+        csr_sign_answer->cert->chain->data = kmalloc(srclen, GFP_KERNEL);
+        csr_sign_answer->cert->chain->data_len = base64_decode(csr_sign_answer->cert->chain->data, srclen, raw, srclen);
     }
 
     return csr_sign_answer;

--- a/commands.c
+++ b/commands.c
@@ -296,6 +296,13 @@ csr_sign_answer *send_csrsign_command(unsigned char *csr)
         srclen = strlen(raw);
         csr_sign_answer->cert->chain->data = kmalloc(srclen, GFP_KERNEL);
         csr_sign_answer->cert->chain->data_len = base64_decode(csr_sign_answer->cert->chain->data, srclen, raw, srclen);
+
+        int result = decode_cert(csr_sign_answer->cert);
+        if (result < 0)
+        {
+            errormsg = "could not decode generated certificate";
+            goto error;
+        }
     }
 
     return csr_sign_answer;

--- a/commands.c
+++ b/commands.c
@@ -297,7 +297,7 @@ csr_sign_answer *send_csrsign_command(unsigned char *csr)
         csr_sign_answer->cert->chain->data = kmalloc(srclen, GFP_KERNEL);
         csr_sign_answer->cert->chain->data_len = base64_decode(csr_sign_answer->cert->chain->data, srclen, raw, srclen);
 
-        int result = decode_cert(csr_sign_answer->cert);
+        int result = set_cert_validity(csr_sign_answer->cert);
         if (result < 0)
         {
             errormsg = "could not decode generated certificate";

--- a/commands.h
+++ b/commands.h
@@ -14,6 +14,7 @@
 #include "task_context.h"
 #include "bearssl.h"
 #include "socket.h"
+#include "cert_tools.h"
 
 #define COMMAND_TIMEOUT_SECONDS 1
 
@@ -26,10 +27,7 @@ typedef struct command_answer
 typedef struct csr_sign_answer
 {
     char *error;
-    br_x509_certificate *chain;
-    size_t chain_len;
-    br_x509_trust_anchor *trust_anchors;
-    size_t trust_anchors_len;
+    x509_certificate *cert;
 } csr_sign_answer;
 
 void free_command_answer(command_answer *cmd_answer);

--- a/device_driver.c
+++ b/device_driver.c
@@ -29,14 +29,8 @@
 
 static int major; /* major number assigned to our device driver */
 
-enum
-{
-    CDEV_NOT_USED = 0,
-    CDEV_EXCLUSIVE_OPEN = 1,
-};
-
 /* Is device open? Used to prevent multiple access to device */
-static atomic_t already_open = ATOMIC_INIT(CDEV_NOT_USED);
+atomic_t already_open = ATOMIC_INIT(CDEV_NOT_USED);
 
 static char device_buffer[DEVICE_BUFFER_SIZE];
 static size_t device_buffer_size = 0;

--- a/device_driver.h
+++ b/device_driver.h
@@ -22,6 +22,14 @@ wasm_vm_result load_module(const char *name, const char *code, unsigned length, 
 #define DEVICE_NAME "nasp"                 /* Dev name as it appears in /dev/devices   */
 #define DEVICE_BUFFER_SIZE 2 * 1024 * 1024 /* Max length of the message from the device */
 
+enum
+{
+    CDEV_NOT_USED = 0,
+    CDEV_EXCLUSIVE_OPEN = 1,
+};
+
+extern atomic_t already_open;
+
 int chardev_init(void);
 void chardev_exit(void);
 

--- a/opa.h
+++ b/opa.h
@@ -28,7 +28,6 @@ typedef struct
     char *uri;
     char *allowed_spiffe_ids[MAX_ALLOWED_SPIFFE_ID];
     int allowed_spiffe_ids_length;
-    u32  keyid;
 } opa_socket_context;
 
 void opa_socket_context_free(opa_socket_context ctx);

--- a/opa.h
+++ b/opa.h
@@ -28,6 +28,7 @@ typedef struct
     char *uri;
     char *allowed_spiffe_ids[MAX_ALLOWED_SPIFFE_ID];
     int allowed_spiffe_ids_length;
+    u32  keyid;
 } opa_socket_context;
 
 void opa_socket_context_free(opa_socket_context ctx);

--- a/rsa_tools.c
+++ b/rsa_tools.c
@@ -15,7 +15,7 @@
 
 static br_hmac_drbg_context hmac_drbg_ctx;
 
-#define RSA_BIT_LENGHT 2048
+#define RSA_BIT_LENGTH 2048
 #define RSA_PUB_EXP 3
 
 // BearSSL RSA Keygen related functions
@@ -39,10 +39,10 @@ uint32_t generate_rsa_keys(br_rsa_private_key *rsa_priv, br_rsa_public_key *rsa_
 {
     br_rsa_keygen rsa_keygen = br_rsa_keygen_get_default();
 
-    unsigned char *raw_priv_key = kmalloc(BR_RSA_KBUF_PRIV_SIZE(RSA_BIT_LENGHT), GFP_KERNEL);
-    unsigned char *raw_pub_key = kmalloc(BR_RSA_KBUF_PUB_SIZE(RSA_BIT_LENGHT), GFP_KERNEL);
+    unsigned char *raw_priv_key = kmalloc(BR_RSA_KBUF_PRIV_SIZE(RSA_BIT_LENGTH), GFP_KERNEL);
+    unsigned char *raw_pub_key = kmalloc(BR_RSA_KBUF_PUB_SIZE(RSA_BIT_LENGTH), GFP_KERNEL);
 
-    return rsa_keygen(&hmac_drbg_ctx.vtable, rsa_priv, raw_priv_key, rsa_pub, raw_pub_key, RSA_BIT_LENGHT, RSA_PUB_EXP);
+    return rsa_keygen(&hmac_drbg_ctx.vtable, rsa_priv, raw_priv_key, rsa_pub, raw_pub_key, RSA_BIT_LENGTH, RSA_PUB_EXP);
 }
 
 void free_rsa_private_key(br_rsa_private_key *key)
@@ -86,7 +86,7 @@ void free_br_x509_trust_anchors(br_x509_trust_anchor *trust_anchors, size_t trus
 }
 
 // BearSSL RSA Keygen related functions
-// Encodes rsa private key to pkcs8 der format and returns it's lenght.
+// Encodes rsa private key to pkcs8 der format and returns it's length.
 // If the der parameter is set to NULL then it computes only the length
 int encode_rsa_priv_key_to_der(unsigned char *der, br_rsa_private_key *rsa_priv, br_rsa_public_key *rsa_pub)
 {
@@ -94,7 +94,7 @@ int encode_rsa_priv_key_to_der(unsigned char *der, br_rsa_private_key *rsa_priv,
     size_t priv_exponent_size = rsa_priv_exp_comp(NULL, rsa_priv, RSA_PUB_EXP);
     if (priv_exponent_size == 0)
     {
-        pr_err("rsa_tools: error happened during priv_exponent lenght calculation");
+        pr_err("rsa_tools: error happened during priv_exponent length calculation");
         return -1;
     }
     unsigned char priv_exponent[priv_exponent_size];

--- a/rsa_tools.c
+++ b/rsa_tools.c
@@ -57,6 +57,34 @@ void free_rsa_public_key(br_rsa_public_key *key)
     kfree(key);
 }
 
+void free_br_x509_certificate(br_x509_certificate *chain, size_t chain_len)
+{
+    if (chain_len > 0)
+    {
+        size_t i;
+        for (i = 0; i < chain_len; i++)
+        {
+            kfree(chain[i].data);
+        }
+    }
+    kfree(chain);
+}
+
+void free_br_x509_trust_anchors(br_x509_trust_anchor *trust_anchors, size_t trust_anchor_len)
+{
+    if (trust_anchor_len > 0)
+    {
+        size_t i;
+        for (i = 0; i < trust_anchor_len; i++)
+        {
+            kfree(trust_anchors[i].dn.data);
+            kfree(trust_anchors[i].pkey.key.rsa.n);
+            kfree(trust_anchors[i].pkey.key.rsa.e);
+        }
+    }
+    kfree(trust_anchors);
+}
+
 // BearSSL RSA Keygen related functions
 // Encodes rsa private key to pkcs8 der format and returns it's lenght.
 // If the der parameter is set to NULL then it computes only the length

--- a/rsa_tools.h
+++ b/rsa_tools.h
@@ -17,6 +17,8 @@ int init_rnd_gen(void);
 uint32_t generate_rsa_keys(br_rsa_private_key *rsa_priv, br_rsa_public_key *rsa_pub);
 void free_rsa_private_key(br_rsa_private_key *key);
 void free_rsa_public_key(br_rsa_public_key *key);
+void free_br_x509_certificate(br_x509_certificate *chain, size_t chain_len);
+void free_br_x509_trust_anchors(br_x509_trust_anchor *trust_anchors, size_t trust_anchor_len);
 int encode_rsa_priv_key_to_der(unsigned char *der, br_rsa_private_key *rsa_priv, br_rsa_public_key *rsa_pub);
 
 #endif

--- a/socket.c
+++ b/socket.c
@@ -1272,7 +1272,7 @@ void socket_exit(void)
 
 	//- free global tls key
 	free_rsa_private_key(rsa_priv);
-	free_rsa_pubplic_key(rsa_pub);
+	free_rsa_public_key(rsa_pub);
 	// kfree(rsa_priv);
 	// kfree(rsa_pub);
 

--- a/socket.c
+++ b/socket.c
@@ -776,7 +776,7 @@ int (*connect)(struct sock *sk, struct sockaddr *uaddr, int addr_len);
 struct sock *(*accept_v6)(struct sock *sk, int flags, int *err, bool kern);
 int (*connect_v6)(struct sock *sk, struct sockaddr *uaddr, int addr_len);
 
-static int handle_cert_gen(nasp_socket *sc, u32 key)
+static int handle_cert_gen(nasp_socket *sc)
 {
 	// Generating certificate signing request
 	if (sc->rsa_priv->plen == 0 || sc->rsa_pub->elen == 0)
@@ -879,7 +879,7 @@ static int handle_cert_gen(nasp_socket *sc, u32 key)
 	return 0;
 }
 
-static int cache_and_validate_cert(nasp_socket *sc, u32 key)
+static int cache_and_validate_cert(nasp_socket *sc, char* key)
 {
 	// Check if cert gen is required or we already have a cached certificate for this socket.
 	u16 cert_validation_err_no = 0;
@@ -887,7 +887,7 @@ static int cache_and_validate_cert(nasp_socket *sc, u32 key)
 	if (!cached_cert_bundle)
 	{
 	regen_cert:
-		int err = handle_cert_gen(sc, key);
+		int err = handle_cert_gen(sc);
 		if (err == -1)
 		{
 			return -1;
@@ -1000,7 +1000,7 @@ struct sock *nasp_accept(struct sock *sk, int flags, int *err, bool kern)
 		memcpy(sc->rsa_priv, rsa_priv, sizeof *sc->rsa_priv);
 		memcpy(sc->rsa_pub, rsa_pub, sizeof *sc->rsa_pub);
 
-		int result = cache_and_validate_cert(sc, sc->opa_socket_ctx.keyid);
+		int result = cache_and_validate_cert(sc, sc->opa_socket_ctx.id);
 		if (result == -1)
 		{
 			goto error;
@@ -1130,7 +1130,7 @@ int nasp_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 		memcpy(sc->rsa_priv, rsa_priv, sizeof *sc->rsa_priv);
 		memcpy(sc->rsa_pub, rsa_pub, sizeof *sc->rsa_pub);
 
-		int result = cache_and_validate_cert(sc, sc->opa_socket_ctx.keyid);
+		int result = cache_and_validate_cert(sc, sc->opa_socket_ctx.id);
 		if (result == -1)
 		{
 			goto error;

--- a/socket.c
+++ b/socket.c
@@ -908,7 +908,7 @@ static int cache_and_validate_cert(nasp_socket *sc, char *key)
 	if (!validate_cert(sc->chain))
 	{
 		pr_warn("nasp: provided certificate is invalid");
-		remove_cert_from_cache_locked(cached_cert_bundle);
+		remove_cert_from_cache(cached_cert_bundle);
 		cert_validation_err_no++;
 		if (cert_validation_err_no == 1)
 		{

--- a/socket.c
+++ b/socket.c
@@ -877,8 +877,6 @@ static int cache_and_validate_cert(nasp_socket *sc, char *key)
 	// Check if cert gen is required or we already have a cached certificate for this socket.
 	u16 cert_validation_err_no = 0;
 
-	remove_unused_expired_certs_from_cache();
-
 	cert_with_key *cached_cert_bundle = find_cert_from_cache(key);
 	if (!cached_cert_bundle)
 	{
@@ -897,7 +895,7 @@ static int cache_and_validate_cert(nasp_socket *sc, char *key)
 		sc->cert = cached_cert_bundle->cert;
 	}
 	// Validate the cached or the generated cert
-	if (!validate_cert(sc->cert->chain))
+	if (!validate_cert(sc->cert->validity))
 	{
 		pr_warn("nasp: provided certificate is invalid");
 		remove_cert_from_cache(cached_cert_bundle);

--- a/socket.c
+++ b/socket.c
@@ -295,8 +295,8 @@ static void nasp_socket_free(nasp_socket *s)
 		buffer_free(s->read_buffer);
 		buffer_free(s->write_buffer);
 
-		kfree(s->rsa_priv);
-		kfree(s->rsa_pub);
+		free_rsa_private_key(s->rsa_priv);
+		free_rsa_public_key(s->rsa_pub);
 		kfree(s->parameters);
 		kfree(s);
 	}

--- a/socket.c
+++ b/socket.c
@@ -962,6 +962,12 @@ struct sock *nasp_accept(struct sock *sk, int flags, int *err, bool kern)
 		goto error;
 	}
 
+	// return if the agent is not running
+	if (atomic_read(&already_open) == CDEV_NOT_USED)
+	{
+		return client;
+	}
+
 	u16 port = (u16)(sk->sk_portpair >> 16);
 
 	sc = nasp_socket_accept(client);
@@ -1088,6 +1094,12 @@ int nasp_connect(struct sock *sk, struct sockaddr *uaddr, int addr_len)
 	if (err != 0)
 	{
 		goto error;
+	}
+
+	// return if the agent is not running
+	if (atomic_read(&already_open) == CDEV_NOT_USED)
+	{
+		return err;
 	}
 
 	pr_info("nasp: nasp_connect uid: %d app: %s to port: %d", current_uid().val, current->comm, port);

--- a/socket.c
+++ b/socket.c
@@ -908,7 +908,7 @@ static int cache_and_validate_cert(nasp_socket *sc, char *key)
 	if (!validate_cert(sc->chain))
 	{
 		pr_warn("nasp: provided certificate is invalid");
-		remove_cert_from_cache(cached_cert_bundle);
+		remove_cert_from_cache_locked(cached_cert_bundle);
 		cert_validation_err_no++;
 		if (cert_validation_err_no == 1)
 		{

--- a/socket.c
+++ b/socket.c
@@ -1062,8 +1062,6 @@ error:
 	if (client)
 		client->sk_prot->close(client, 0);
 
-	pr_err("nasp: [%s] accept error, socket closed", current->comm);
-
 	return NULL;
 }
 
@@ -1194,8 +1192,6 @@ error:
 	lock_sock(sk);
 	sk->sk_prot->close(sk, 0);
 	release_sock(sk);
-
-	pr_err("nasp: [%s] connect error, socket closed", current->comm);
 
 	return err;
 }

--- a/socket.c
+++ b/socket.c
@@ -1271,10 +1271,10 @@ void socket_exit(void)
 	tcpv6_prot.connect = connect_v6;
 
 	//- free global tls key
-	// free_rsa_private_key(rsa_priv);
-	// free_rsa_pubplic_key(rsa_pub);
-	kfree(rsa_priv);
-	kfree(rsa_pub);
+	free_rsa_private_key(rsa_priv);
+	free_rsa_pubplic_key(rsa_pub);
+	// kfree(rsa_priv);
+	// kfree(rsa_pub);
 
 	pr_info("nasp: socket support unloaded.");
 }


### PR DESCRIPTION
## Description

Implement cert bundle caching.
From now on, if the certificate used by the server/client is valid, it will be reused.
This is the initial implementation of caching, which uses a linked list and removes the certificate bundles only if they are no longer valid. During the next iteration, we are going to introduce some form of garbage collection to this cache.

## Type of Change

- [ ] Bug Fix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
