### PR TITLE
using online CPU count instead of possible

### DIFF
--- a/device_driver.c
+++ b/device_driver.c
@@ -128,7 +128,7 @@ wasm_vm_result load_module(const char *name, const char *code, unsigned length, 
 {
     wasm_vm_result result;
     unsigned cpu;
-    for_each_possible_cpu(cpu)
+    for_each_online_cpu(cpu)
     {
         wasm_vm *vm = wasm_vm_for_cpu(cpu);
         wasm_vm_lock(vm);

--- a/main.c
+++ b/main.c
@@ -41,7 +41,7 @@ MODULE_PARM_DESC(ktls_available, "Marks if kTLS is available on the system");
 
 static int __init nasp_init(void)
 {
-    pr_info("module loaded at 0x%p running on %d CPUs", nasp_init, nr_cpu_ids);
+    pr_info("module loaded at 0x%p running on %d CPUs", nasp_init, num_online_cpus());
 
     wasm_vm_result result = wasm_vm_new_per_cpu();
     if (result.err)

--- a/opa.c
+++ b/opa.c
@@ -665,7 +665,7 @@ void load_opa_data(const char *data)
 {
     unsigned cpu;
 
-    for_each_possible_cpu(cpu)
+    for_each_online_cpu(cpu)
     {
         opa_wrapper *opa = opas[cpu];
         wasm_vm_lock(opa->vm);

--- a/wasm.c
+++ b/wasm.c
@@ -90,8 +90,11 @@ wasm_vm *this_cpu_wasm_vm(void)
 
 wasm_vm *wasm_vm_for_cpu(unsigned cpu)
 {
-    if (cpu >= nr_cpu_ids)
+    if (cpu >= num_online_cpus())
+    {
+        pr_err("cpu[%d] is not online", cpu);
         return NULL;
+    }
     return vms[cpu];
 }
 
@@ -103,7 +106,7 @@ const char *wasm_vm_last_error(wasm_vm_module *module)
 wasm_vm_result wasm_vm_new_per_cpu(void)
 {
     int cpu = 0;
-    for_each_possible_cpu(cpu)
+    for_each_online_cpu(cpu)
     {
         pr_info("create vm # cpu[%d]", cpu);
         vms[cpu] = wasm_vm_new(cpu);
@@ -116,7 +119,7 @@ wasm_vm_result wasm_vm_destroy_per_cpu(void)
     if (vms[0])
     {
         int cpu = 0;
-        for_each_possible_cpu(cpu)
+        for_each_online_cpu(cpu)
         {
             pr_info("destroy vm # cpu[%d]", cpu);
             wasm_vm_destroy(vms[cpu]);


### PR DESCRIPTION
Online CPUs reflect much better how many CPUs are available currently on a given system, possible CPUs caused creation of more CPUs than really available on cloud environments.

Also don't use the nr_cpu_ids variable directly, instead call num_online_cpus()