### PR TITLE
setsockopt controllable client TLS enablement

### DIFF
--- a/nasp.h
+++ b/nasp.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2023 Cisco and/or its affiliates. All rights reserved.
+ *
+ * SPDX-License-Identifier: MIT OR GPL-2.0-only
+ *
+ * Licensed under the MIT license <LICENSE.MIT or https://opensource.org/licenses/MIT> or the GPLv2 license
+ * <LICENSE.GPL or https://opensource.org/license/gpl-2-0>, at your option. This file may not be copied,
+ * modified, or distributed except according to those terms.
+ */
+
+#ifndef nasp_h
+#define nasp_h
+
+#define SOL_NASP 7891
+#define NASP_HOSTNAME 1
+
+typedef struct nasp_tls
+{
+} nasp_tls;
+
+#endif /* nasp_h */

--- a/socket.c
+++ b/socket.c
@@ -820,8 +820,6 @@ int nasp_setsockopt(struct sock *sk, int level,
 					int optname, sockptr_t optval,
 					unsigned int optlen)
 {
-	printk(KERN_INFO "nasp_setsockopt called # command[%s] sk[%p] level[%d] optname[%d] optlen[%d]\n", current->comm, sk, level, optname, optlen);
-
 	if (level == SOL_TCP && optname == TCP_ULP)
 	{
 		// check if optval is "nasp"

--- a/tls.h
+++ b/tls.h
@@ -26,9 +26,10 @@ typedef struct br_x509_nasp_context
     const br_x509_class *vtable;
     br_x509_minimal_context ctx;
     opa_socket_context *socket_context;
+    bool insecure;
 } br_x509_nasp_context;
 
-void br_x509_nasp_init(br_x509_nasp_context *ctx, br_ssl_engine_context *eng, opa_socket_context *socket_context);
+void br_x509_nasp_init(br_x509_nasp_context *ctx, br_ssl_engine_context *eng, opa_socket_context *socket_context, bool insecure);
 void br_x509_nasp_free(br_x509_nasp_context *ctx);
 
 #endif


### PR DESCRIPTION
## Description

This PR introduces a new socket option to enable the NASP ULP on the socket programatically, thus no agent is needed (this can be done from kernel and user space code as well):

NOTE: currently server CA verification is not yet implemented, so we run with 'insecure skip verify' mode.

```c
error = sock_create(AF_INET, SOCK_STREAM, IPPROTO_TCP, &sock);
if (error < 0)
{
    printk(KERN_ERR "error creating socket\n");
    return error;
}


// Enable the nasp middleware for this socket
sock->ops->setsockopt(sock, SOL_TCP, TCP_ULP, KERNEL_SOCKPTR("nasp"), sizeof("nasp"));

// Set hostname for validation
char hostname[] = "aws.amazon.com";
sock->ops->setsockopt(sock, SOL_NASP, NASP_HOSTNAME, KERNEL_SOCKPTR(hostname), sizeof(hostname));

```

https://github.com/bonifaido/test-kernel-module/blob/main/main.c#L46

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
